### PR TITLE
Adapt children PropType check to newer React versions

### DIFF
--- a/lib/react-simpletabs.jsx
+++ b/lib/react-simpletabs.jsx
@@ -16,7 +16,7 @@ var Tabs = React.createClass({
     onAfterChange: React.PropTypes.func,
     children: React.PropTypes.oneOfType([
       React.PropTypes.array,
-      React.PropTypes.component
+      React.PropTypes.element
     ]).isRequired
   },
   getDefaultProps () {


### PR DESCRIPTION
when mounting this component the following error was showing in console:
`Warning: React.PropTypes.component will be deprecated in a future version. Use React.PropTypes.element instead.`

This update should avoid such a warning and make react-simpletabs future compatible