### PR TITLE
Install fewer files when using bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,6 +25,9 @@
     "node_modules",
     "bower_components",
     "test",
-    "tests"
+    "tests",
+    "example",
+    "utils",
+    "lib"
   ]
 }


### PR DESCRIPTION
Assuming that bower users will consume the `dist` files, there is no reason for them to have the raw source, the utils or the example when installing. This should reduce the impact a bit.