### PR TITLE
Package.json: move react from dependencies to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
       "json"
     ]
   },
-  "dependencies": {
+  "peerDependencies": {
     "react": "^0.12.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This fixes issue "Cannot read property 'firstChild' of undefined" that happens when 2 versions of react are loaded simultaneously.