### PR TITLE
Allow title to be compound object

### DIFF
--- a/lib/react-simpletabs.jsx
+++ b/lib/react-simpletabs.jsx
@@ -124,7 +124,7 @@ var Tabs = React.createClass({
 Tabs.Panel = React.createClass({
   displayName: 'Panel',
   propTypes: {
-    title: React.PropTypes.string.isRequired,
+    title: React.PropTypes.any.isRequired,
     children: React.PropTypes.oneOfType([
       React.PropTypes.array,
       React.PropTypes.element


### PR DESCRIPTION
I have titles that are not strings, but rather more complex renders (e.g. <span>Example</span>).
This allows to put badges or labels in the tab title.